### PR TITLE
Assistant checkpoint: Fix Replit Auth strategy name consistency

### DIFF
--- a/server/replitAuth.ts
+++ b/server/replitAuth.ts
@@ -116,10 +116,10 @@ export async function setupAuth(app: Express) {
     },
     verify,
   );
-  passport.use(strategy);
+  passport.use("replit-auth", strategy);
 
-  // Get the actual strategy name (it includes the domain)
-  const strategyName = strategy.name;
+  // Use a fixed strategy name instead of the dynamic one
+  const strategyName = "replit-auth";
   console.log("🔐 Registered Replit Auth strategy with name:", strategyName);
 
   passport.serializeUser((user: Express.User, cb) => cb(null, user));


### PR DESCRIPTION
Assistant generated file changes:
- server/replitAuth.ts: Fix Replit Auth strategy registration and session handling

---

User prompt:

fix the replit login issue

Replit-Commit-Author: Assistant
Replit-Commit-Session-Id: 5ad5ea06-ef17-45cd-a6ed-3639f7b13a75